### PR TITLE
Bac 2972 color message based on regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 aws-sns-hipchat
 ===============
 
-A simple AWS SNS HTTP(s) endpoint to send notification to HipChat chatroom. 
+A simple AWS SNS HTTP(s) endpoint to send notification to HipChat chatroom or Jenkins Job.
 
 ## Features
 
 * Designed to run on Heroku
 * Automatically confirm subscription
 * Send notifications to multiple chatrooms
+* Send notifications to multiple Jenkins Jobs.
 * Heroku-compatible logs for every notification and subscribe confirmation
 
-The HTTP(s) API is `http://aws-sns-hipchat.herokuapp.com/ROOM_ID`, which could be used to register as endpoints on SNS.
+The HTTP(s) API are `http://aws-sns-hipchat.herokuapp.com/sns/hipchat/ROOM_ID` and `http://aws-sns-hipchat.herokuapp.com/sns/jenkins/JOB_NAME`, which could be used to register as endpoints on SNS.
 
 ## Heroku Deployment
 
@@ -24,11 +25,19 @@ If you're not familiar with using Go on Heroku, check [Getting Started with Go o
 
 ## Configuration
 
-To make this app up and work properly, you need to set an environment variable `HIPCHAT_AUTH_TOKEN` as your API auth token of HipChat:
+To make this app up and work properly, you need to set an environment variable `HIPCHAT_AUTH_TOKEN` as your API auth token of HipChat.
+If you wish to use jenkins, se also `JENKINS_TOKEN` and `JENKINS_URL`.
 
 ```bash
 heroku config:add HIPCHAT_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+heroku config:add JENKINS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+heroku config:add JENKINS_URL=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 ```
+
+## Missing feature
+
+Verify signature
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ heroku config:add JENKINS_URL=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ```
 
-## Missing feature
+## Signatures
 
-Verify signature
+Signature of the messages send to jenkins are verified.
 
 ## Contact
 

--- a/conf.json
+++ b/conf.json
@@ -1,0 +1,7 @@
+{
+  "Colors": {
+    "\\[INFO\\]": "gray",
+    "\\[WARNING\\]": "yellow",
+    "\\[BLOCKER\\]": "red"
+  }
+}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ type AutoScalingNotification struct {
 	EndTime string `url:"EndTime"`
 	StatusCode string `url:"StatusCode"`
 	StatusMessage string `url:"StatusMessage"`
-	Progress string `url:"Progress"`
+	Progress int `url:"Progress"`
 	EC2InstanceId string `url:"EC2InstanceId"`
 	Details string `url:"Details"`
 	Token string `url:"token"`

--- a/main.go
+++ b/main.go
@@ -103,6 +103,12 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	job_name := args["job_name"]
 
 	var n AutoScalingNotification
+
+	defer r.Body.Close()
+
+	content, _ := ioutil.ReadAll(r.Body)
+	fmt.Printf("%s\n", string(content))
+
 	dec := json.NewDecoder(r.Body)
 	err := dec.Decode(&n)
 

--- a/main.go
+++ b/main.go
@@ -203,6 +203,16 @@ func TriggerJob(job_name string, n AutoScalingNotification) {
 func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	job_name := args["job_name"]
 
+	// Debug purpose
+	bodyIo, errBody := ioutil.ReadAll(r.Body);
+
+	if errBody != nil {
+		fmt.Printf("Error when reading body : %s", errBody)
+	}
+
+	fmt.Printf("Body of the request: %s", bodyIo)
+	// end debug
+
 	var notif Notification
 	var autoScalNotif AutoScalingNotification
 

--- a/main.go
+++ b/main.go
@@ -101,6 +101,11 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	var notif Notification
 	var autoScalNotif AutoScalingNotification
 
+	defer r.Body.Close()
+
+	content, _ := ioutil.ReadAll(r.Body)
+	fmt.Printf("%s\n", string(content))
+
 	dec := json.NewDecoder(r.Body)
 	err := dec.Decode(&notif)
 
@@ -116,8 +121,6 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(message_byte, &autoScalNotif)
 
 	if (err != nil) {
-		content, _ := ioutil.ReadAll(r.Body)
-		fmt.Printf("%s\n", string(content))
 
 		fmt.Printf("%s\n", notif.Message)
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ type AutoScalingNotification struct {
 	StatusMessage string `url:"StatusMessage"`
 	Progress int `url:"Progress"`
 	EC2InstanceId string `url:"EC2InstanceId"`
-	Details string `url:"Details"`
+	//Details string `url:"Details"`
 	Token string `url:"token"`
 }
 
@@ -117,7 +117,6 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(message_byte, &autoScalNotif)
 
 	if (err != nil) {
-
 		fmt.Printf("%s\n", notif.Message)
 		fmt.Println(err)
 		http.Error(w, "Invalid JSON.", http.StatusBadRequest)

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	if (err != nil) {
 		content, _ := ioutil.ReadAll(r.Body)
 		fmt.Printf("%s\n", string(content))
+		fmt.Println(err)
 
 		http.Error(w, "Invalid JSON.", http.StatusBadRequest)
 		return
@@ -148,7 +149,8 @@ func ServeHTTP(args martini.Params, w http.ResponseWriter, r *http.Request, h Hi
   err := dec.Decode(&n)
 
   if (err != nil) {
-    http.Error(w, "Invalid JSON.", http.StatusBadRequest)
+	fmt.Println(err)
+	http.Error(w, "Invalid JSON.", http.StatusBadRequest)
     return
   }
 

--- a/main.go
+++ b/main.go
@@ -203,15 +203,15 @@ func TriggerJob(job_name string, n AutoScalingNotification) {
 func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	job_name := args["job_name"]
 
-	// Debug purpose
-	bodyIo, errBody := ioutil.ReadAll(r.Body);
-
-	if errBody != nil {
-		fmt.Printf("Error when reading body : %s", errBody)
-	}
-
-	fmt.Printf("Body of the request: %s", bodyIo)
-	// end debug
+//	// Debug purpose
+//	bodyIo, errBody := ioutil.ReadAll(r.Body);
+//
+//	if errBody != nil {
+//		fmt.Printf("Error when reading body : %s", errBody)
+//	}
+//
+//	fmt.Printf("Body of the request: %s", bodyIo)
+//	// end debug
 
 	var notif Notification
 	var autoScalNotif AutoScalingNotification

--- a/main.go
+++ b/main.go
@@ -101,11 +101,6 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	var notif Notification
 	var autoScalNotif AutoScalingNotification
 
-	defer r.Body.Close()
-
-	content, _ := ioutil.ReadAll(r.Body)
-	fmt.Printf("%s\n", string(content))
-
 	dec := json.NewDecoder(r.Body)
 	err := dec.Decode(&notif)
 
@@ -123,7 +118,7 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	if (err != nil) {
 
 		fmt.Printf("%s\n", notif.Message)
-
+		fmt.Println(err)
 		http.Error(w, "Invalid JSON.", http.StatusBadRequest)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func (h HipChatSender)SendMessage(room_id, message string) error {
 
 func TriggerJob(job_name string, n AutoScalingNotification) {
 
-	apiUrl := "http://jenkins.ifeelgoods.com/buildByToken/buildWithParameters?job=" + job_name
+	apiUrl := jenkins_url + "/buildByToken/buildWithParameters?job=" + job_name
 
 	n.Token = jenkins_token
 
@@ -116,6 +116,9 @@ func SnsJenkins(args martini.Params, w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(message_byte, &autoScalNotif)
 
 	if (err != nil) {
+		content, _ := ioutil.ReadAll(r.Body)
+		fmt.Printf("%s\n", string(content))
+
 		fmt.Printf("%s\n", notif.Message)
 
 		http.Error(w, "Invalid JSON.", http.StatusBadRequest)
@@ -171,13 +174,14 @@ func ServeHTTP(args martini.Params, w http.ResponseWriter, r *http.Request, h Hi
 }
 
 var jenkins_token string
+var jenkins_url string
 
 func main() {
 	fmt.Println("Starting aws-sns proxy server.")
 	m := martini.Classic()
 	h := HipChatSender{AuthToken: os.Getenv("HIPCHAT_AUTH_TOKEN")}
 	jenkins_token = os.Getenv("JENKINS_TOKEN")
-
+	jenkins_url = os.Getenv("JENKINS_URL")
 	m.Map(h)
 
 	m.Post("/sns/hipchat/:room_id", ServeHTTP)


### PR DESCRIPTION
Features
=======
Can now render hipchat message in different colors.
At startup, the server load a `config.json`file lik in the example below

```json
{
  "Colors": {
    "\\[INFO\\]": "gray",
    "\\[WARNING\\]": "yellow",
    "\\[BLOCKER\\]": "red"
  }
}
```
`Colors`is a map from a regexp to an hipchat color. The sever will apply the first matched regexp to the subject of the message

Notes
====
Currently we recompile all regexp for each request. we should do that only at startup

Jira
===
https://ifeelgoods.atlassian.net/browse/BAC-2972
 
  